### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "git clone https://github.com/git-game/git-game-v2.git"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/git-game/git-game-v2)](https://repl.it/github/git-game/git-game-v2)
+
 #git-game-v2
 
 This repo is the sequel to the [git-game](https://github.com/git-game/git-game).


### PR DESCRIPTION
I think running on repl.it lowers the entry bar for games like this, especially for really new beginners where learning CLI is a great way to start. It might be a useful feature!

This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dialogarithm/git-game-v2).